### PR TITLE
Update package build configuration to include missing dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ license = { file = "LICENSE.md" }
 keywords = ["fhir", "fhirpath"]
 dynamic = ["version"]
 authors = [{ name = "beda.software", email = "fhirpath@beda.software" }]
-dependencies = ["antlr4-python3-runtime~=4.10", "python-dateutil==2.8.2"]
+dependencies = ["antlr4-python3-runtime~=4.10", "python-dateutil~=2.8.2"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ license = { file = "LICENSE.md" }
 keywords = ["fhir", "fhirpath"]
 dynamic = ["version"]
 authors = [{ name = "beda.software", email = "fhirpath@beda.software" }]
-dependencies = ["antlr4-python3-runtime~=4.10"]
+dependencies = ["antlr4-python3-runtime~=4.10", "python-dateutil==2.8.2"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",


### PR DESCRIPTION
fhirpathpy package installed into a virtualenv fails to run `evaluate` raising
> ModuleNotFoundError: No module named 'dateutil'