### PR TITLE
Fix formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,22 +56,27 @@ result = evaluate(patient, "Patient.name.where(use='usual').given.first()", [])
 ```
 
 ## evaluate
- > Evaluates the "path" FHIRPath expression on the given resource, using data
-    from "context" for variables mentioned in the "path" expression.
-    Parameters:
-    resource (dict|list): FHIR resource, bundle as js object or array of resources This resource will be modified by this function to add type information.
-    path (string): fhirpath expression, sample 'Patient.name.given'
-    context (dict): a hash of variable name/value pairs.
-    model (dict): The "model" data object specific to a domain, e.g. R4.
-    Returns:
-    int: Description of return value
+Evaluates the "path" FHIRPath expression on the given resource, using data from "context" for variables mentioned in the "path" expression.
+
+**Parameters**
+
+resource (dict|list): FHIR resource, bundle as js object or array of resources This resource will be modified by this function to add type information.
+
+path (string): fhirpath expression, sample 'Patient.name.given'
+
+context (dict): a hash of variable name/value pairs.
+
+model (dict): The "model" data object specific to a domain, e.g. R4.
+
+**Returns**
+
+int: Description of return value
 
 ## compile
-> Returns a function that takes a resource and an optional context hash (see
-    "evaluate"), and returns the result of evaluating the given FHIRPath
-    expression on that resource.  The advantage of this function over "evaluate"
-    is that if you have multiple resources, the given FHIRPath expression will
-    only be parsed once.
-    Parameters:
-    path (string) - the FHIRPath expression to be parsed.
-    model (dict) - The "model" data object specific to a domain, e.g. R4.
+Returns a function that takes a resource and an optional context hash (see "evaluate"), and returns the result of evaluating the given FHIRPath expression on that resource.  The advantage of this function over "evaluate" is that if you have multiple resources, the given FHIRPath expression will only be parsed once
+
+**Parameters**
+
+path (string) - the FHIRPath expression to be parsed.
+
+model (dict) - The "model" data object specific to a domain, e.g. R4.


### PR DESCRIPTION
The function descriptions were challenging to follow previously because it was all on one line in Github's online rendering - I spaced them out a bit.