### PR TITLE
Support `collection.abc.Mapping` as resource instead of only `dict`

### DIFF
--- a/fhirpathpy/engine/evaluators/__init__.py
+++ b/fhirpathpy/engine/evaluators/__init__.py
@@ -1,12 +1,12 @@
-import json
-import re
 from collections import abc
 from decimal import Decimal
 from functools import reduce
 
+import re
+import json
 import fhirpathpy.engine as engine
-import fhirpathpy.engine.nodes as nodes
 import fhirpathpy.engine.util as util
+import fhirpathpy.engine.nodes as nodes
 
 
 def boolean_literal(ctx, parentData, node):
@@ -71,10 +71,8 @@ def alias_op_expression(mapFn):
     def func(ctx, parentData, node):
         op = node["terminalNodeText"][0]
 
-        if op not in mapFn:
-            raise Exception(
-                "Do not know how to alias " + op + " by " + json.dumps(mapFn)
-            )
+        if not op in mapFn:
+            raise Exception("Do not know how to alias " + op + " by " + json.dumps(mapFn))
 
         alias = mapFn[op]
         return engine.infix_invoke(ctx, alias, parentData, node["children"])
@@ -108,7 +106,7 @@ def external_constant_term(ctx, parent_data, node):
     ext_identifier = ext_constant["children"][0]
     varName = identifier(ctx, parent_data, ext_identifier)[0].replace("`", "")
 
-    if varName not in ctx["vars"]:
+    if not varName in ctx["vars"]:
         return []
 
     value = ctx["vars"][varName]
@@ -181,7 +179,7 @@ def create_reduce_member_invocation(model, key):
         toAdd = None
         toAdd_ = None
 
-        if isinstance(model, abc.Mapping):
+        if isinstance(model, dict):
             childPath = model["pathsDefinedElsewhere"].get(childPath, childPath)
             actualTypes = model["choiceTypePaths"].get(childPath)
 
@@ -287,9 +285,7 @@ def polarity_expression(ctx, parentData, node):
     rtn = engine.do_eval(ctx, parentData, node["children"][0])
 
     if len(rtn) != 1:  # not yet in spec, but per Bryn Rhodes
-        raise Exception(
-            "Unary " + sign + " can only be applied to an individual number."
-        )
+        raise Exception("Unary " + sign + " can only be applied to an individual number.")
 
     if not util.is_number(rtn[0]):
         raise Exception("Unary " + sign + " can only be applied to a number.")
@@ -325,9 +321,7 @@ evaluators = {
     # expressions
     "PolarityExpression": polarity_expression,
     "IndexerExpression": indexer_expression,
-    "MembershipExpression": alias_op_expression(
-        {"contains": "containsOp", "in": "inOp"}
-    ),
+    "MembershipExpression": alias_op_expression({"contains": "containsOp", "in": "inOp"}),
     "TermExpression": term_expression,
     "UnionExpression": union_expression,
     "InvocationExpression": invocation_expression,

--- a/fhirpathpy/engine/evaluators/__init__.py
+++ b/fhirpathpy/engine/evaluators/__init__.py
@@ -1,12 +1,12 @@
+import json
+import re
 from collections import abc
 from decimal import Decimal
 from functools import reduce
 
-import re
-import json
 import fhirpathpy.engine as engine
-import fhirpathpy.engine.util as util
 import fhirpathpy.engine.nodes as nodes
+import fhirpathpy.engine.util as util
 
 
 def boolean_literal(ctx, parentData, node):
@@ -71,8 +71,10 @@ def alias_op_expression(mapFn):
     def func(ctx, parentData, node):
         op = node["terminalNodeText"][0]
 
-        if not op in mapFn:
-            raise Exception("Do not know how to alias " + op + " by " + json.dumps(mapFn))
+        if op not in mapFn:
+            raise Exception(
+                "Do not know how to alias " + op + " by " + json.dumps(mapFn)
+            )
 
         alias = mapFn[op]
         return engine.infix_invoke(ctx, alias, parentData, node["children"])
@@ -106,7 +108,7 @@ def external_constant_term(ctx, parent_data, node):
     ext_identifier = ext_constant["children"][0]
     varName = identifier(ctx, parent_data, ext_identifier)[0].replace("`", "")
 
-    if not varName in ctx["vars"]:
+    if varName not in ctx["vars"]:
         return []
 
     value = ctx["vars"][varName]
@@ -179,7 +181,7 @@ def create_reduce_member_invocation(model, key):
         toAdd = None
         toAdd_ = None
 
-        if isinstance(model, dict):
+        if isinstance(model, abc.Mapping):
             childPath = model["pathsDefinedElsewhere"].get(childPath, childPath)
             actualTypes = model["choiceTypePaths"].get(childPath)
 
@@ -285,7 +287,9 @@ def polarity_expression(ctx, parentData, node):
     rtn = engine.do_eval(ctx, parentData, node["children"][0])
 
     if len(rtn) != 1:  # not yet in spec, but per Bryn Rhodes
-        raise Exception("Unary " + sign + " can only be applied to an individual number.")
+        raise Exception(
+            "Unary " + sign + " can only be applied to an individual number."
+        )
 
     if not util.is_number(rtn[0]):
         raise Exception("Unary " + sign + " can only be applied to a number.")
@@ -321,7 +325,9 @@ evaluators = {
     # expressions
     "PolarityExpression": polarity_expression,
     "IndexerExpression": indexer_expression,
-    "MembershipExpression": alias_op_expression({"contains": "containsOp", "in": "inOp"}),
+    "MembershipExpression": alias_op_expression(
+        {"contains": "containsOp", "in": "inOp"}
+    ),
     "TermExpression": term_expression,
     "UnionExpression": union_expression,
     "InvocationExpression": invocation_expression,

--- a/fhirpathpy/engine/evaluators/__init__.py
+++ b/fhirpathpy/engine/evaluators/__init__.py
@@ -1,3 +1,4 @@
+from collections import abc
 from decimal import Decimal
 from functools import reduce
 
@@ -185,7 +186,7 @@ def create_reduce_member_invocation(model, key):
         if isinstance(res.data, nodes.FP_Quantity):
             toAdd = res.data.value
 
-        if actualTypes and isinstance(res.data, dict):
+        if actualTypes and isinstance(res.data, abc.Mapping):
             # Use actualTypes to find the field's value
             for actualType in actualTypes:
                 field = f"{key}{actualType}"
@@ -194,7 +195,7 @@ def create_reduce_member_invocation(model, key):
                 if toAdd is not None or toAdd_ is not None:
                     childPath += actualType
                     break
-        elif isinstance(res.data, dict):
+        elif isinstance(res.data, abc.Mapping):
             toAdd = res.data.get(key)
             toAdd_ = res.data.get(f"_{key}")
             if key == "extension":

--- a/fhirpathpy/engine/invocations/equality.py
+++ b/fhirpathpy/engine/invocations/equality.py
@@ -1,3 +1,4 @@
+from collections import abc
 from decimal import Decimal
 import json
 import fhirpathpy.engine.util as util
@@ -80,9 +81,9 @@ def equivalence(ctx, x, y):
     if isinstance(x_val, nodes.FP_Quantity) and isinstance(y_val, nodes.FP_Quantity):
         return x_val.deep_equal(y_val)
 
-    if isinstance(a, (dict, list)) and isinstance(b, (dict, list)):
+    if isinstance(a, (abc.Mapping, list)) and isinstance(b, (abc.Mapping, list)):
         def deep_equal(a, b):
-            if isinstance(a, dict) and isinstance(b, dict):
+            if isinstance(a, abc.Mapping) and isinstance(b, abc.Mapping):
                 if a.keys() != b.keys():
                     return False
                 return all(deep_equal(a[key], b[key]) for key in a)

--- a/fhirpathpy/engine/invocations/filtering.py
+++ b/fhirpathpy/engine/invocations/filtering.py
@@ -1,3 +1,4 @@
+from collections import abc
 from decimal import Decimal
 import numbers
 import fhirpathpy.engine.util as util
@@ -121,7 +122,7 @@ def extension(ctx, data, url):
     res = []
     for d in data:
         element = util.get_data(d)
-        if isinstance(element, dict):
+        if isinstance(element, abc.Mapping):
             exts = [e for e in element.get("extension", []) if e["url"] == url]
             if len(exts) > 0:
                 res.append(nodes.ResourceNode.create_node(exts[0], "Extension"))

--- a/fhirpathpy/engine/invocations/navigation.py
+++ b/fhirpathpy/engine/invocations/navigation.py
@@ -1,3 +1,4 @@
+from collections import abc
 from functools import reduce
 import fhirpathpy.engine.util as util
 import fhirpathpy.engine.nodes as nodes
@@ -15,7 +16,7 @@ def create_reduce_children(ctx):
         if isinstance(data, list):
             data = dict((i, data[i]) for i in range(0, len(data)))
 
-        if isinstance(data, dict):
+        if isinstance(data, abc.Mapping):
             for prop in data.keys():
                 value = data[prop]
                 childPath = ""

--- a/fhirpathpy/engine/nodes.py
+++ b/fhirpathpy/engine/nodes.py
@@ -1,3 +1,4 @@
+from collections import abc
 import copy
 from datetime import datetime, timedelta, timezone
 from dateutil.relativedelta import relativedelta
@@ -824,7 +825,7 @@ class ResourceNode:
         If data is a resource (maybe a contained resource) reset the path
         information to the resource type.
         """
-        if isinstance(data, dict) and "resourceType" in data:
+        if isinstance(data, abc.Mapping) and "resourceType" in data:
             path = data["resourceType"]
 
         self.path = path
@@ -872,7 +873,7 @@ class ResourceNode:
         cls = TypeInfo.type_to_class_with_check_string.get(self.path)
         if cls:
             data = FP_TimeBase.check_string(cls, data) or data
-        if isinstance(data, dict) and data["system"] == "http://unitsofmeasure.org":
+        if isinstance(data, abc.Mapping) and data["system"] == "http://unitsofmeasure.org":
             data = FP_Quantity(
                 data["value"],
                 FP_Quantity.timeUnitsToUCUM.get(data["code"], "'" + data["code"] + "'"),
@@ -934,7 +935,7 @@ class TypeInfo:
             name = "Quantity"
         elif isinstance(value, str):
             name = "string"
-        elif isinstance(value, dict):
+        elif isinstance(value, abc.Mapping):
             name = "object"
 
         if name == "bool":

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -1,7 +1,10 @@
 import json
+from collections.abc import Mapping
+from dataclasses import dataclass, fields
 from datetime import datetime, timezone
-from unittest import mock
 from decimal import Decimal
+from unittest import mock
+
 import pytest
 
 from fhirpathpy import evaluate
@@ -274,4 +277,119 @@ def combining_functions_test(resource, path, expected):
     ],
 )
 def path_functions_test(resource, path, expected):
+    assert evaluate(resource, path) == expected
+
+
+
+@dataclass(eq=True)
+class NestedMapping(Mapping):
+    d: int
+    e: str
+
+    def __iter__(self):
+        return iter([field.name for field in fields(self)])
+
+    def __getitem__(self, key: str):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def __len__(self):
+        return len(fields(self))
+
+
+@dataclass(eq=True)
+class CustomMapping(Mapping):
+    a: int
+    b: dict
+    c: NestedMapping
+    d: tuple[NestedMapping, ...]
+    e: list[NestedMapping]
+
+    def __iter__(self):
+        return iter([field.name for field in fields(self)])
+
+    def __getitem__(self, key: str):
+        try:
+            return getattr(self, key)
+        except AttributeError:
+            raise KeyError(key)
+
+    def __len__(self):
+        return len(fields(self))
+
+
+@pytest.mark.parametrize(
+    ("resource", "path", "expected"),
+    [
+        (
+            CustomMapping(
+                a=1,
+                b={"c": True},
+                c=NestedMapping(d=3, e="f"),
+                d=(NestedMapping(d=4, e="x"), NestedMapping(d=3, e="y")),
+                e=[NestedMapping(d=4, e="z"), NestedMapping(d=5, e="w")],
+            ),
+            "a",
+            [1],
+        ),
+        (
+            CustomMapping(
+                a=1,
+                b={"c": True},
+                c=NestedMapping(d=3, e="f"),
+                d=(NestedMapping(d=4, e="x"), NestedMapping(d=3, e="y")),
+                e=[NestedMapping(d=4, e="z"), NestedMapping(d=5, e="w")],
+            ),
+            "b.c",
+            [True],
+        ),
+        (
+            CustomMapping(
+                a=1,
+                b={"c": True},
+                c=NestedMapping(d=3, e="f"),
+                d=(NestedMapping(d=4, e="x"), NestedMapping(d=3, e="y")),
+                e=[NestedMapping(d=4, e="z"), NestedMapping(d=5, e="w")],
+            ),
+            "c",
+            [NestedMapping(d=3, e="f")],
+        ),
+        (
+            CustomMapping(
+                a=1,
+                b={"c": True},
+                c=NestedMapping(d=3, e="f"),
+                d=(NestedMapping(d=4, e="x"), NestedMapping(d=3, e="y")),
+                e=[NestedMapping(d=4, e="z"), NestedMapping(d=5, e="w")],
+            ),
+            "c.d",
+            [3],
+        ),
+        (
+            CustomMapping(
+                a=1,
+                b={"c": True},
+                c=NestedMapping(d=3, e="f"),
+                d=(NestedMapping(d=4, e="x"), NestedMapping(d=3, e="y")),
+                e=[NestedMapping(d=4, e="z"), NestedMapping(d=5, e="w")],
+            ),
+            "e.last()",
+            [NestedMapping(d=5, e="w")],
+        ),
+        (
+            CustomMapping(
+                a=1,
+                b={"c": True},
+                c=NestedMapping(d=3, e="f"),
+                d=(NestedMapping(d=4, e="x"), NestedMapping(d=3, e="y")),
+                e=[NestedMapping(d=4, e="z"), NestedMapping(d=5, e="w")],
+            ),
+            "e.where(d=5)",
+            [NestedMapping(d=5, e="w")],
+        )
+    ],
+)
+def mappings_test(resource, path, expected):
     assert evaluate(resource, path) == expected


### PR DESCRIPTION
This slight modification to the engine relaxes the assumption that a resource node must be a Python `dictionary` by changing
some `isinstance` checks: 

```diff
- if isinstance(node.data, dict):
+ if isinstance(node.data, Mapping):
```

This allows us to pass Pydantic objects or dataclasses and preserve metadata and methods defined on those objects and solves the issue described here #43.

Let me know what you think and if adaptation are needed 🙌 

FYI: I think a similar relaxation of `list` to `Sequence` would also be possible 🙂 