### PR TITLE
Fix is_true regression for ResourceNode-wrapped booleans.

### DIFF
--- a/fhirpathpy/engine/util.py
+++ b/fhirpathpy/engine/util.py
@@ -60,7 +60,9 @@ def is_nullable(x):
 
 
 def is_true(x):
-    return x is True or isinstance(x, list) and len(x) == 1 and x[0] is True
+    # Use == not is: mid-pipeline values are often ResourceNode wrappers; __eq__
+    # compares .data, while `is True` does not (see fhirpathpy 2.2.1 regression).
+    return x == True or isinstance(x, list) and len(x) == 1 and x[0] == True  # noqa: E712
 
 
 def arraify(x, instead_none=None):

--- a/tests/cases/5.1_existence.yaml
+++ b/tests/cases/5.1_existence.yaml
@@ -117,6 +117,14 @@ tests:
     expression: (0|1|2|3).all($this = $index)
     result: [true]
 
+  - desc: '** all with boolean field criterium (all true)'
+    expression: Functions.coll1.colltrue.attr.all($this)
+    result: [true]
+
+  - desc: '** all with boolean field criterium (contains false)'
+    expression: Functions.coll1.collwithfalse.attr.all($this)
+    result: [false]
+
 
   - desc: '5.1.5. allTrue() : boolean'
 # Takes a collection of boolean values and returns

--- a/tests/cases/5.5_conversion.yaml
+++ b/tests/cases/5.5_conversion.yaml
@@ -38,6 +38,14 @@ tests:
     expression: Functions.iif(false, 'a')
     result: []
 
+  - desc: '** iif with boolean field as criterium (true)'
+    expression: Functions.iif(attrtrue, 'a', 'b')
+    result: ['a']
+
+  - desc: '** iif with boolean field as criterium (false)'
+    expression: Functions.iif(attrfalse, 'a', 'b')
+    result: ['b']
+
   - desc: '5.5.2. toInteger() : integer'
     # If the input collection contains a single item, this functio# n will return a single integer if:
     # the item in the input collection is an integer


### PR DESCRIPTION
Revert `is True` to `== True` in is_true so iif/all treat mid-pipeline ResourceNode conditions correctly after the 2.2.1 ruff cleanup.