### PR TITLE
fix: return empty collection when join() is called on empty collection (Fixes #65)

### DIFF
--- a/fhirpathpy/engine/invocations/strings.py
+++ b/fhirpathpy/engine/invocations/strings.py
@@ -125,6 +125,9 @@ def decode(ctx, coll, format):
 
 
 def join(ctx, coll, separator=""):
+    if not coll:
+        return []
+
     stringValues = []
     for n in coll:
         d = util.get_data(n)

--- a/tests/test_evaluators.py
+++ b/tests/test_evaluators.py
@@ -95,6 +95,22 @@ def string_functions_test(resource, path, expected):
     assert evaluate(resource, path) == expected
 
 
+@pytest.mark.parametrize(
+    ("resource", "path", "expected"),
+    [
+        # join on empty collection should return empty per FHIRPath spec
+        ({"a": []}, "a.join(',')", []),
+        ({"a": []}, "a.join()", []),
+        # join on non-empty collection still works
+        ({"a": ["hello", "world"]}, "a.join(',')", ["hello,world"]),
+        ({"a": ["hello", "world"]}, "a.join()", ["helloworld"]),
+        ({"a": ["a", "b", "c"]}, "a.join('-')", ["a-b-c"]),
+    ],
+)
+def join_function_test(resource, path, expected):
+    assert evaluate(resource, path) == expected
+
+
 """
 'select'
 'ofType'


### PR DESCRIPTION
Fixes #65

## Problem

Per the [FHIRPath specification](https://build.fhir.org/ig/HL7/FHIRPath/#joinseparator-string--string), `join()` applied to an empty collection should return an **empty collection**, not an empty string:

> If the input collection is empty, the result is empty.

Previously, the `join` function called `separator.join([])` which returns `""`, and this empty string was returned directly — violating the spec.

## Solution

Added an empty collection check at the beginning of the `join` function in `fhirpathpy/engine/invocations/strings.py`. When the input collection is empty, the function now returns `[]` instead of `""`.

This is consistent with how all other FHIRPath functions in this codebase handle empty collections (e.g., `matches`, `replace`, `contains`, etc. all return `[]` for empty inputs).

## Verification

```
$ python -m pytest tests/ -x -q -o "addopts="
============================= 1657 passed in 1.32s ==============================
```

All 5 new join tests pass (empty + non-empty cases) alongside the existing 1652 tests.

---

**About the Author:** Raphael Malikian — Clinical AI Solutions Architect. I specialise in building and fixing AI/ML systems for healthcare, including vector databases, RAG pipelines, and clinical NLP. If you need help with your project or think I can add value to your organisation, feel free to reach out — I'd love to connect.

📧 rtmalikian@gmail.com
🔗 GitHub: https://github.com/rtmalikian
🔗 LinkedIn: http://www.linkedin.com/in/raphael-t-malikian-mbbs-bsc-hons-71075436a

---

**Disclosure:** This code was developed with assistance from **mimo-2.5-pro** (Xiaomi) via **Hermes Agent** (Nous Research). All changes were reviewed, tested against the actual codebase, and verified for correctness.
